### PR TITLE
Support compressed requests/responses on fetch

### DIFF
--- a/fetch-rss
+++ b/fetch-rss
@@ -103,7 +103,7 @@ sub my_description {
 $tmp = "/tmp/feed.$$.rss";
 system("curl", "-s", "-o", $tmp, "-m", "5", "-L",
        "-A", "Gwene/1.0 (The gwene.org rss-to-news gateway)",
-       $source);
+       "--compressed", $source);
 if ($? != 0) {
     if (-f $tmp) {
 	unlink $tmp;


### PR DESCRIPTION
When curl is built with support for compression (which is the case
for most distributions and most configurations), the --compressed
option makes it send request with Accept-Encoding, allowing the returned
response to be compressed, reducing the traffic necessary to the fetching.
